### PR TITLE
add Swift on Android and Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS (build & test)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Show Swift version
+        run: swift --version
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test
+
+  linux:
+    name: Linux (build & test)
+    runs-on: ubuntu-latest
+    container: swift:6.1
+    steps:
+      - uses: actions/checkout@v7
+      - name: Show Swift version
+        run: swift --version
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test
+
+  android:
+    name: Android (cross-compile & test on emulator)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build and test Swift package on Android
+        uses: skiptools/swift-android-action@v2
+        with:
+          # Cross-compiles the package for Android and runs the XCTest suite
+          # inside an Android emulator (run-tests defaults to true).
+          swift-version: "6.1"
+          free-disk-space: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # UTMConversion
+[![CI](https://github.com/wtw-software/UTMConversion/actions/workflows/ci.yml/badge.svg)](https://github.com/wtw-software/UTMConversion/actions/workflows/ci.yml)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.svg?v=103)](https://opensource.org/licenses/mit-license.php)
 
-Convert between latitude/longitude and the [UTM (Universal Transverse Mercator)](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system) coordinate systems. The conversion happens between a custom `struct` `UTMCoordinate` and CoreLocation's `CLLocationCoordinate2D` and `CLLocation`.
+Convert between latitude/longitude and the [UTM (Universal Transverse Mercator)](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system) coordinate systems. The conversion happens between a custom `struct` `UTMCoordinate` and either the portable `GeoCoordinate` `struct` (available on every platform) or, on Apple platforms, CoreLocation's `CLLocationCoordinate2D` and `CLLocation`.
+
+## Platform support
+
+The core conversion math is platform-neutral and depends only on Foundation, so it runs on:
+
+- iOS 14.0+ / macOS 10.13+ (with full CoreLocation support)
+- Android (via the [official Swift Android SDK](https://www.swift.org/documentation/articles/getting-started-with-android.html))
+- Linux
+
+On Apple platforms the CoreLocation-based API (`CLLocationCoordinate2D` / `CLLocation` extensions, and `UTMCoordinate.coordinate()` / `UTMCoordinate.location()`) is available exactly as before. On Android and Linux, where CoreLocation is unavailable, use the portable `GeoCoordinate` type instead.
 
 ## Requirements
 
-- iOS 12.0+ / macOS 10.10+
+- iOS 14.0+ / macOS 10.13+ (Apple platforms), or Android / Linux with a Swift 6.0+ toolchain
 
 ## Installation
 ### Carthage
@@ -66,3 +77,20 @@ let utmCoordinate = UTMCoordinate(northing: 7034313, easting: 569612, zone: 32, 
 let datum = UTMDatum(equitorialRadius: 6378137, polarRadius: 6356752.3142)
 let coordinate = utmCoordinate.coordinate(datum: datum)
 ```
+
+### Android / Linux (CoreLocation-free)
+
+On platforms without CoreLocation, use the portable `GeoCoordinate` type. It has the same `latitude`/`longitude` shape and exposes the same conversions:
+
+```swift
+import UTMConversion
+
+// latitude/longitude -> UTM
+let geoCoordinate = GeoCoordinate(latitude: 63.430493678423012, longitude: 10.394966844991798)
+let utmCoordinate = geoCoordinate.utmCoordinate()
+
+// UTM -> latitude/longitude
+let back = utmCoordinate.geoCoordinate()
+```
+
+`GeoCoordinate` also works on Apple platforms, and `CLLocationCoordinate2D` exposes a `.geoCoordinate` bridging property, so shared code can target the portable type everywhere.

--- a/Sources/UTMConversion/CLLocation+UTMCoordinate.swift
+++ b/Sources/UTMConversion/CLLocation+UTMCoordinate.swift
@@ -1,18 +1,18 @@
-import CoreLocation
+#if canImport(CoreLocation)
 import Foundation
+import CoreLocation
 
 public extension CLLocation {
-    
+
     /**
         Calculates the UTM coordinate of the receiver
-     
+
         - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
-     
+
      */
     func utmCoordinate(datum: UTMDatum = UTMDatum.wgs84) -> UTMCoordinate {
-        let coordinate = self.coordinate
-        let zone = coordinate.zone
-        return TMCoordinate(coordinate: coordinate, centralMeridian: zone.centralMeridian, datum: datum).utmCoordinate(zone: zone, hemisphere: coordinate.hemisphere)
+        return coordinate.utmCoordinate(datum: datum)
     }
-    
+
 }
+#endif

--- a/Sources/UTMConversion/CLLocationCoordinate2D+UTMCoordinate.swift
+++ b/Sources/UTMConversion/CLLocationCoordinate2D+UTMCoordinate.swift
@@ -1,33 +1,40 @@
+#if canImport(CoreLocation)
 import Foundation
 import CoreLocation
 
 public extension CLLocationCoordinate2D {
-    
-    
+
+    /**
+     A portable `GeoCoordinate` with the same latitude/longitude
+     */
+    var geoCoordinate: GeoCoordinate {
+        return GeoCoordinate(latitude: latitude, longitude: longitude)
+    }
+
     /**
      Calculates the UTM coordinate of the receiver
-     
+
      - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
-     
+
      */
     func utmCoordinate(datum: UTMDatum = UTMDatum.wgs84) -> UTMCoordinate {
-        let zone = self.zone
-        return TMCoordinate(coordinate: self, centralMeridian: zone.centralMeridian, datum: datum).utmCoordinate(zone: zone, hemisphere: hemisphere)
+        return geoCoordinate.utmCoordinate(datum: datum)
     }
-    
-    
+
+
     /**
      The UTM grid zone
      */
     var zone: UTMGridZone {
-        return UTMGridZone(floor((longitude + 180.0) / 6)) + 1;
+        return geoCoordinate.zone
     }
-    
+
     /**
      The UTM hemisphere
      */
     var hemisphere: UTMHemisphere {
-        return latitude < 0 ? .southern : .northern
+        return geoCoordinate.hemisphere
     }
-    
+
 }
+#endif

--- a/Sources/UTMConversion/GeoCoordinate.swift
+++ b/Sources/UTMConversion/GeoCoordinate.swift
@@ -1,0 +1,65 @@
+#if canImport(Foundation)
+import Foundation
+#endif
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#endif
+
+/**
+    A portable latitude/longitude coordinate.
+
+    `GeoCoordinate` is the platform-neutral coordinate type used by the
+    conversion math. On Apple platforms it bridges to and from CoreLocation's
+    `CLLocationCoordinate2D`, but it is available everywhere Foundation is
+    (including Android and Linux), which lets UTM conversions run without
+    CoreLocation.
+ */
+public struct GeoCoordinate: Equatable, Sendable {
+
+    /** The latitude in degrees */
+    public let latitude: Double
+
+    /** The longitude in degrees */
+    public let longitude: Double
+
+    /**
+        Initializes a geographic coordinate.
+
+        - Parameter latitude: The latitude in degrees
+        - Parameter longitude: The longitude in degrees
+     */
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+public extension GeoCoordinate {
+
+    /**
+        Calculates the UTM coordinate of the receiver
+
+        - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
+     */
+    func utmCoordinate(datum: UTMDatum = UTMDatum.wgs84) -> UTMCoordinate {
+        let zone = self.zone
+        return TMCoordinate(coordinate: self, centralMeridian: zone.centralMeridian, datum: datum).utmCoordinate(zone: zone, hemisphere: hemisphere)
+    }
+
+    /**
+        The UTM grid zone
+     */
+    var zone: UTMGridZone {
+        return UTMGridZone(floor((longitude + 180.0) / 6)) + 1
+    }
+
+    /**
+        The UTM hemisphere
+     */
+    var hemisphere: UTMHemisphere {
+        return latitude < 0 ? .southern : .northern
+    }
+}

--- a/Sources/UTMConversion/TMCoordinate.swift
+++ b/Sources/UTMConversion/TMCoordinate.swift
@@ -1,5 +1,12 @@
-import CoreLocation
+#if canImport(Foundation)
 import Foundation
+#endif
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#endif
 
 let utmScaleFactor = 0.9996
 
@@ -30,13 +37,13 @@ struct TMCoordinate {
     }
     
     /**
-        Init with a CLLocationCoordinate
-     
+        Init with a GeoCoordinate
+
         - Parameter coordinate: The coordinate to init with
         - Parameter centralMeridian: The central meridian of the earth
         - Parameter datum: The datum to use
      */
-    init(coordinate: CLLocationCoordinate2D, centralMeridian: Double, datum: UTMDatum) {
+    init(coordinate: GeoCoordinate, centralMeridian: Double, datum: UTMDatum) {
         let phi = toRadians(degrees: coordinate.latitude) // Latitude in radians
         let lambda = toRadians(degrees: coordinate.longitude) // Longitude in radians
         
@@ -131,9 +138,9 @@ struct TMCoordinate {
      
         - Parameter centralMeridian: The central meridian of the earth
         - Parameter datum: The datum to use
-     
+
      */
-    func coordinate(centralMeridian: Double, datum: UTMDatum) -> CLLocationCoordinate2D {
+    func coordinate(centralMeridian: Double, datum: UTMDatum) -> GeoCoordinate {
         /* The local variables Nf, nuf2, tf, and tf2 serve the same purpose as N, nu2, t, and t2 in MapLatLonToXY, but they are computed with respect to the footpoint latitude phif. x1frac, x2frac, x2poly, x3poly, etc. are to enhance readability and to optimize computations. */
 
         let x = easting
@@ -204,7 +211,7 @@ struct TMCoordinate {
         /* Calculate longitude */
         let longitudeRadians = centralMeridian + x1frac * x + x3frac * x3poly * pow(x, 3.0) + x5frac * x5poly * pow(x, 5.0) + x7frac * x7poly * pow(x, 7.0)
         
-        return CLLocationCoordinate2D(latitude: toDegrees(radians: latitudeRadians), longitude: toDegrees(radians: longitudeRadians))
+        return GeoCoordinate(latitude: toDegrees(radians: latitudeRadians), longitude: toDegrees(radians: longitudeRadians))
     }
     
     /**

--- a/Sources/UTMConversion/UTMCoordinate.swift
+++ b/Sources/UTMConversion/UTMCoordinate.swift
@@ -1,5 +1,16 @@
-import CoreLocation
+#if canImport(Foundation)
 import Foundation
+#endif
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#endif
+
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 
 /** UTM grid zone is a positive number between 1 and 60 */
 public typealias UTMGridZone = UInt
@@ -19,7 +30,7 @@ extension UTMGridZone {
     - northern: The northern hemisphere
     - southern: The southern hemisphere
  */
-public enum UTMHemisphere {
+public enum UTMHemisphere: Sendable {
     case northern
     case southern
 }
@@ -27,7 +38,7 @@ public enum UTMHemisphere {
 /**
     Geodetic datum to define the size of the earth, given as equitorial and polar radius.
  */
-public struct UTMDatum {
+public struct UTMDatum: Sendable {
     /** The radius around the equator */
     public let equitorialRadius: Double
     
@@ -46,7 +57,7 @@ public struct UTMDatum {
 /**
     Universal Transverse Mercator (UTM) coordinate which divies the earth into 60 different zones. The coordinates northing and easting are relative to the specified zone, and are also relative to the hemisphere.
  */
-public struct UTMCoordinate {
+public struct UTMCoordinate: Sendable {
     
     /** Northing, corresponds to the latitude */
     public let northing: Double
@@ -71,22 +82,38 @@ public struct UTMCoordinate {
     }
     
     /**
-        Calculates the latitude/longitude coordinate of the receiver
-     
+        Calculates the portable latitude/longitude coordinate of the receiver
+
         - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
      */
-    public func coordinate(datum: UTMDatum = UTMDatum.wgs84) -> CLLocationCoordinate2D {
+    public func geoCoordinate(datum: UTMDatum = UTMDatum.wgs84) -> GeoCoordinate {
         return TMCoordinate(utmCoordinate: self).coordinate(centralMeridian: zone.centralMeridian, datum: datum)
     }
-    
+
+}
+
+#if canImport(CoreLocation)
+public extension UTMCoordinate {
+
     /**
-        Calculates the location (CLLocation) coordinate of the receiver
-     
+        Calculates the latitude/longitude coordinate of the receiver
+
         - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
      */
-    public func location(datum: UTMDatum = UTMDatum.wgs84) -> CLLocation {
+    func coordinate(datum: UTMDatum = UTMDatum.wgs84) -> CLLocationCoordinate2D {
+        let geo = geoCoordinate(datum: datum)
+        return CLLocationCoordinate2D(latitude: geo.latitude, longitude: geo.longitude)
+    }
+
+    /**
+        Calculates the location (CLLocation) coordinate of the receiver
+
+        - Parameter datum: The datum to use, defaults to WGS84 which should be fine for most applications
+     */
+    func location(datum: UTMDatum = UTMDatum.wgs84) -> CLLocation {
         let coordinateStruct = coordinate(datum: datum)
         return CLLocation(latitude: coordinateStruct.latitude, longitude: coordinateStruct.longitude)
     }
-    
+
 }
+#endif

--- a/Tests/UTMConversionTests/UTMConversionTests.swift
+++ b/Tests/UTMConversionTests/UTMConversionTests.swift
@@ -1,117 +1,186 @@
-import CoreLocation
 import UTMConversion
 import XCTest
 
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+
 class UTMConversionTests: XCTestCase {
-    
-    func testCLLocationCoordinate2D_utmCoordinate() {
+
+    // MARK: - Portable tests (run on every platform, including Android/Linux)
+
+    func testGeoCoordinate_utmCoordinate() {
         let osloUTM = oslo.utmCoordinate()
-        XCTAssertEqual(osloUTM.northing, 6643010.0, accuracy: 0.00001);
-        XCTAssertEqual(osloUTM.easting, 598430.0, accuracy: 0.00001);
+        XCTAssertEqual(osloUTM.northing, 6643010.0, accuracy: 0.00001)
+        XCTAssertEqual(osloUTM.easting, 598430.0, accuracy: 0.00001)
         XCTAssertEqual(osloUTM.zone, 32)
         XCTAssertEqual(osloUTM.hemisphere, .northern)
-        
+
         let trondheimUTM = trondheim.utmCoordinate()
         XCTAssertEqual(trondheimUTM.northing, 7034313, accuracy: 0.00001)
         XCTAssertEqual(trondheimUTM.easting, 569612, accuracy: 0.00001)
         XCTAssertEqual(trondheimUTM.zone, 32)
         XCTAssertEqual(trondheimUTM.hemisphere, .northern)
-        
+
         let johannesburgUTM = johannesburg.utmCoordinate()
         XCTAssertEqual(johannesburgUTM.northing, 7100115, accuracy: 0.00001)
         XCTAssertEqual(johannesburgUTM.easting, 603914, accuracy: 0.00001)
         XCTAssertEqual(johannesburgUTM.zone, 35)
         XCTAssertEqual(johannesburgUTM.hemisphere, .southern)
-        
+
         let buninyongUTM = buninyong.utmCoordinate()
         XCTAssertEqual(buninyongUTM.northing, 5828674.33994, accuracy: 0.00001)
         XCTAssertEqual(buninyongUTM.easting, 758173.79835, accuracy: 0.00001)
         XCTAssertEqual(buninyongUTM.zone, 54)
         XCTAssertEqual(buninyongUTM.hemisphere, .southern)
     }
-    
-    func testCLLocation_utmCoordinate() {
-        let osloUTM = osloLocation.utmCoordinate()
-        XCTAssertEqual(osloUTM.northing, 6643010.0, accuracy: 0.00001);
-        XCTAssertEqual(osloUTM.easting, 598430.0, accuracy: 0.00001);
+
+    func testUTMCoordinate_geoCoordinate() {
+        let oslo = osloUTM.geoCoordinate()
+        XCTAssertEqual(oslo.latitude, 59.912814611065265)
+        XCTAssertEqual(oslo.longitude, 10.760192985178369)
+
+        let trondheim = trondheimUTM.geoCoordinate()
+        XCTAssertEqual(trondheim.latitude, 63.430493678423012)
+        XCTAssertEqual(trondheim.longitude, 10.394966844991798)
+
+        let utmJohannesburg = UTMCoordinate(northing: 7100115, easting: 603914, zone: 35, hemisphere: .southern)
+        let johannesburg = utmJohannesburg.geoCoordinate()
+        XCTAssertEqual(johannesburg.latitude, -26.214767103043133)
+        XCTAssertEqual(johannesburg.longitude, 28.040197220939884)
+
+        let buninyong = buninyongUTM.geoCoordinate()
+        XCTAssertEqual(buninyong.latitude, -37.65282114, accuracy: 0.00001)
+        XCTAssertEqual(buninyong.longitude, 143.92649554, accuracy: 0.00001)
+    }
+
+    func testCustomDatumPortable() {
+        let oslo = osloUTM.geoCoordinate(datum: UTMDatum(equitorialRadius: 6378137, polarRadius: 6356752.3142))
+        XCTAssertEqual(oslo.latitude, 59.912814611065265)
+        XCTAssertEqual(oslo.longitude, 10.760192985178369)
+    }
+
+    // MARK: - CoreLocation tests (Apple platforms only)
+
+    #if canImport(CoreLocation)
+    func testCLLocationCoordinate2D_utmCoordinate() {
+        let osloUTM = osloCL.utmCoordinate()
+        XCTAssertEqual(osloUTM.northing, 6643010.0, accuracy: 0.00001)
+        XCTAssertEqual(osloUTM.easting, 598430.0, accuracy: 0.00001)
         XCTAssertEqual(osloUTM.zone, 32)
         XCTAssertEqual(osloUTM.hemisphere, .northern)
-        
+
+        let trondheimUTM = trondheimCL.utmCoordinate()
+        XCTAssertEqual(trondheimUTM.northing, 7034313, accuracy: 0.00001)
+        XCTAssertEqual(trondheimUTM.easting, 569612, accuracy: 0.00001)
+        XCTAssertEqual(trondheimUTM.zone, 32)
+        XCTAssertEqual(trondheimUTM.hemisphere, .northern)
+
+        let johannesburgUTM = johannesburgCL.utmCoordinate()
+        XCTAssertEqual(johannesburgUTM.northing, 7100115, accuracy: 0.00001)
+        XCTAssertEqual(johannesburgUTM.easting, 603914, accuracy: 0.00001)
+        XCTAssertEqual(johannesburgUTM.zone, 35)
+        XCTAssertEqual(johannesburgUTM.hemisphere, .southern)
+
+        let buninyongUTM = buninyongCL.utmCoordinate()
+        XCTAssertEqual(buninyongUTM.northing, 5828674.33994, accuracy: 0.00001)
+        XCTAssertEqual(buninyongUTM.easting, 758173.79835, accuracy: 0.00001)
+        XCTAssertEqual(buninyongUTM.zone, 54)
+        XCTAssertEqual(buninyongUTM.hemisphere, .southern)
+    }
+
+    func testCLLocation_utmCoordinate() {
+        let osloUTM = osloLocation.utmCoordinate()
+        XCTAssertEqual(osloUTM.northing, 6643010.0, accuracy: 0.00001)
+        XCTAssertEqual(osloUTM.easting, 598430.0, accuracy: 0.00001)
+        XCTAssertEqual(osloUTM.zone, 32)
+        XCTAssertEqual(osloUTM.hemisphere, .northern)
+
         let trondheimUTM = trondheimLocation.utmCoordinate()
         XCTAssertEqual(trondheimUTM.northing, 7034313, accuracy: 0.00001)
         XCTAssertEqual(trondheimUTM.easting, 569612, accuracy: 0.00001)
         XCTAssertEqual(trondheimUTM.zone, 32)
         XCTAssertEqual(trondheimUTM.hemisphere, .northern)
-        
+
         let johannesburgUTM = johannesburgLocation.utmCoordinate()
         XCTAssertEqual(johannesburgUTM.northing, 7100115, accuracy: 0.00001)
         XCTAssertEqual(johannesburgUTM.easting, 603914, accuracy: 0.00001)
         XCTAssertEqual(johannesburgUTM.zone, 35)
         XCTAssertEqual(johannesburgUTM.hemisphere, .southern)
-        
+
         let buninyongUTM = buninyongLocation.utmCoordinate()
         XCTAssertEqual(buninyongUTM.northing, 5828674.33994, accuracy: 0.00001)
         XCTAssertEqual(buninyongUTM.easting, 758173.79835, accuracy: 0.00001)
         XCTAssertEqual(buninyongUTM.zone, 54)
         XCTAssertEqual(buninyongUTM.hemisphere, .southern)
     }
-    
+
     func testUTMCoordinate_coordinate() {
         let oslo = osloUTM.coordinate()
         XCTAssertEqual(oslo.latitude, 59.912814611065265)
         XCTAssertEqual(oslo.longitude, 10.760192985178369)
-        
+
         let trondheim = trondheimUTM.coordinate()
         XCTAssertEqual(trondheim.latitude, 63.430493678423012)
         XCTAssertEqual(trondheim.longitude, 10.394966844991798)
-        
+
         let utmJohannesburg = UTMCoordinate(northing: 7100115, easting: 603914, zone: 35, hemisphere: .southern)
         let johannesburg = utmJohannesburg.coordinate()
         XCTAssertEqual(johannesburg.latitude, -26.214767103043133)
         XCTAssertEqual(johannesburg.longitude, 28.040197220939884)
-        
+
         let buninyong = buninyongUTM.coordinate()
         XCTAssertEqual(buninyong.latitude, -37.65282114, accuracy: 0.00001)
         XCTAssertEqual(buninyong.longitude, 143.92649554, accuracy: 0.00001)
     }
-    
+
     func testUTMCoordinate_location() {
         let oslo = osloUTM.location()
         XCTAssertEqual(oslo.coordinate.latitude, 59.912814611065265)
         XCTAssertEqual(oslo.coordinate.longitude, 10.760192985178369)
-        
+
         let trondheim = trondheimUTM.location()
         XCTAssertEqual(trondheim.coordinate.latitude, 63.430493678423012)
         XCTAssertEqual(trondheim.coordinate.longitude, 10.394966844991798)
-        
+
         let johannesburg = johannesburgUTM.location()
         XCTAssertEqual(johannesburg.coordinate.latitude, -26.214767103043133)
         XCTAssertEqual(johannesburg.coordinate.longitude, 28.040197220939884)
-        
+
         let buninyong = buninyongUTM.location()
         XCTAssertEqual(buninyong.coordinate.latitude, -37.65282114, accuracy: 0.00001)
         XCTAssertEqual(buninyong.coordinate.longitude, 143.92649554, accuracy: 0.00001)
     }
-    
+
     func testCustomDatum() {
         let oslo = osloUTM.location(datum: UTMDatum(equitorialRadius: 6378137, polarRadius: 6356752.3142))
         XCTAssertEqual(oslo.coordinate.latitude, 59.912814611065265)
         XCTAssertEqual(oslo.coordinate.longitude, 10.760192985178369)
     }
+    #endif
 }
 
 
-private let buninyong = CLLocationCoordinate2D(latitude: -37.65282114, longitude: 143.92649554)
-private let oslo = CLLocationCoordinate2D(latitude: 59.912814611065265, longitude: 10.760192985178369)
-private let trondheim = CLLocationCoordinate2D(latitude: 63.430493678423012, longitude: 10.394966844991798)
-private let johannesburg = CLLocationCoordinate2D(latitude: -26.214767103043133, longitude: 28.040197220939884)
+// MARK: - Fixtures
+
+private let buninyong = GeoCoordinate(latitude: -37.65282114, longitude: 143.92649554)
+private let oslo = GeoCoordinate(latitude: 59.912814611065265, longitude: 10.760192985178369)
+private let trondheim = GeoCoordinate(latitude: 63.430493678423012, longitude: 10.394966844991798)
+private let johannesburg = GeoCoordinate(latitude: -26.214767103043133, longitude: 28.040197220939884)
 
 private let buninyongUTM = UTMCoordinate(northing: 5828674.33994, easting: 758173.79835, zone: 54, hemisphere: .southern)
 private let osloUTM = UTMCoordinate(northing: 6643010, easting: 598430, zone: 32, hemisphere: .northern)
 private let trondheimUTM = UTMCoordinate(northing: 7034313, easting: 569612, zone: 32, hemisphere: .northern)
 private let johannesburgUTM = UTMCoordinate(northing: 7100115, easting: 603914, zone: 35, hemisphere: .southern)
 
-private let buninyongLocation = CLLocation(latitude: buninyong.latitude, longitude: buninyong.longitude)
+#if canImport(CoreLocation)
+private let buninyongCL = CLLocationCoordinate2D(latitude: -37.65282114, longitude: 143.92649554)
+private let osloCL = CLLocationCoordinate2D(latitude: 59.912814611065265, longitude: 10.760192985178369)
+private let trondheimCL = CLLocationCoordinate2D(latitude: 63.430493678423012, longitude: 10.394966844991798)
+private let johannesburgCL = CLLocationCoordinate2D(latitude: -26.214767103043133, longitude: 28.040197220939884)
+
+private let buninyongLocation = CLLocation(latitude: -37.65282114, longitude: 143.92649554)
 private let osloLocation = CLLocation(latitude: 59.912814611065265, longitude: 10.760192985178369)
 private let trondheimLocation = CLLocation(latitude: 63.430493678423012, longitude: 10.394966844991798)
 private let johannesburgLocation = CLLocation(latitude: -26.214767103043133, longitude: 28.040197220939884)
+#endif

--- a/UTMConversion.podspec
+++ b/UTMConversion.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'UTMConversion'
   s.version = '1.4.0'
-  s.swift_version = '5.0'
+  s.swift_version = '6.0'
   s.cocoapods_version = '>= 1.4.0'
   s.summary = 'Convert between latitude/longitude and the UTM coordinate system.'
   s.description  = <<~DESC
@@ -16,10 +16,11 @@ Pod::Spec.new do |s|
   s.authors = {
     'Peter Ringset' => 'peter@ringset.no'
   }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '14.0'
+  s.osx.deployment_target = '10.13'
   s.source = {
     git: 'https://github.com/wtw-software/UTMConversion.git',
     tag: s.version
   }
-  s.source_files = 'UTMConversion/*.{swift,h}'
+  s.source_files = 'Sources/UTMConversion/*.{swift,h}'
 end


### PR DESCRIPTION
Hi,

I would like to contribute adding Swift on Android and Linux support.
As I've adapted tests too and included CI, they're also included in the PR.
Changes:

- Introducing a portable GeoCoordinate type as the cross-platform core of the UTM conversion math, gating all CoreLocation API behind canImport(CoreLocation) so the Apple-platform API is unchanged. 
- Add portable tests that run on all platforms.
- Bump swift-tools-version to 6.0.
- Updated readme with new features and fix outdated package versions.
- Updated pods.
- Add a GitHub Actions workflow building and testing on macOS, Linux, and Android (via skiptools/swift-android-action).